### PR TITLE
Fix formatting error and add back inflated variable count

### DIFF
--- a/PizzaTower_GM2/objects/obj_player/Create_0.gml
+++ b/PizzaTower_GM2/objects/obj_player/Create_0.gml
@@ -715,7 +715,7 @@ if (!variable_global_exists("saveroom"))
 	global.reset_timer[obj_pizzard] = 100;
 	global.reset_timer[obj_pepgoblin] = 200;
 	global.reset_timer[obj_pepbat] = 200;
-	global.reset_timer[obj_swedishmonkey	] = 200;
+	global.reset_timer[obj_swedishmonkey] = 200;
 	global.reset_timer[obj_rancher] = 100;
 	global.reset_timer[obj_pickle] = 200;
 	global.reset_timer[obj_tank] = 100;

--- a/PizzaTower_GM2/scripts/tdp_bnvib_update/tdp_bnvib_update.gml
+++ b/PizzaTower_GM2/scripts/tdp_bnvib_update/tdp_bnvib_update.gml
@@ -1,9 +1,3 @@
-
-function tdp_bnvib_update()
-{
-
-}
-
 /*
 function tdp_bnvib_update() { // Inaccurate, probably. Decompiled by yours truly, x64dbg.ru
 	if (IS_SWITCH) { var _; // TODO: Finish
@@ -42,3 +36,11 @@ function tdp_bnvib_update() { // Inaccurate, probably. Decompiled by yours truly
 	}
 }
 */
+function tdp_bnvib_update()
+{
+	if (IS_SWITCH)
+	{
+		// artificially inflate variable count
+		var _, __, ___, ____, _____, ______, _______, ________, _________, __________;	
+	}
+}


### PR DESCRIPTION
I was working on a mod and looked at obj_player's Create event until i saw a whitespace in that line,
and for tdp_bnvib_update, i added back the artificial inflated variable count to make it accurate like it was before.